### PR TITLE
Potential fix for code scanning alert no. 5: Disabled TLS certificate check

### DIFF
--- a/svc-gateway/pkg/mailer/mailer.go
+++ b/svc-gateway/pkg/mailer/mailer.go
@@ -20,7 +20,6 @@ type Mailer struct {
 
 func NewMailer(host string, port int, username, password string) *Mailer {
 	d := gomail.NewDialer(host, port, username, password)
-	d.TLSConfig = &tls.Config{}
 
 	slog.Info("mailer initialized", "host", host, "port", port, "username", username)
 

--- a/svc-gateway/pkg/mailer/mailer.go
+++ b/svc-gateway/pkg/mailer/mailer.go
@@ -1,7 +1,6 @@
 package mailer
 
 import (
-	"crypto/tls"
 	"log/slog"
 
 	"gopkg.in/gomail.v2"

--- a/svc-gateway/pkg/mailer/mailer.go
+++ b/svc-gateway/pkg/mailer/mailer.go
@@ -20,7 +20,7 @@ type Mailer struct {
 
 func NewMailer(host string, port int, username, password string) *Mailer {
 	d := gomail.NewDialer(host, port, username, password)
-	d.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	d.TLSConfig = &tls.Config{}
 
 	slog.Info("mailer initialized", "host", host, "port", port, "username", username)
 


### PR DESCRIPTION
Potential fix for [https://github.com/ZureTz/sci-vault/security/code-scanning/5](https://github.com/ZureTz/sci-vault/security/code-scanning/5)

The secure fix is to stop disabling TLS verification. In this file, the best minimal change that preserves functionality is to configure TLS without `InsecureSkipVerify: true` (or rely on defaults), so certificate and hostname checks remain enabled.

**Best single fix in this snippet:**
- In `svc-gateway/pkg/mailer/mailer.go`, line 23 region in `NewMailer`, replace:
  - `d.TLSConfig = &tls.Config{InsecureSkipVerify: true}`
  with:
  - `d.TLSConfig = &tls.Config{}`
  
This keeps explicit TLS config assignment (so behavior shape remains similar) while restoring secure defaults (`InsecureSkipVerify` defaults to `false`).  
No new methods or definitions are required. Existing imports can remain as-is.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
