### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,22 +20,11 @@ jobs:
       - run: buf --version
       - run: buf build
       - run: buf lint
-      - run: buf generate
-      - uses: actions/upload-artifact@v6
-        with:
-          name: buf-generated
-          path: |
-            svc-gateway/internal/pb/
-            svc-recommender/src/pb/
 
   go-check:
     runs-on: ubuntu-latest
-    needs: buf-check
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v8
-        with:
-          name: buf-generated
       - uses: actions/setup-go@v6
         with:
           go-version: "1.26.0"
@@ -49,12 +38,8 @@ jobs:
 
   python-check:
     runs-on: ubuntu-latest
-    needs: buf-check
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v8
-        with:
-          name: buf-generated
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["master"]
 
+permissions:
+  contents: read
+
 jobs:
   buf-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ZureTz/sci-vault/security/code-scanning/4](https://github.com/ZureTz/sci-vault/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yaml` so all jobs inherit restricted token permissions by default.

Best single fix without changing functionality:
- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

This addresses the CodeQL finding and enforces least privilege across all jobs unless overridden later. No imports, methods, or extra definitions are needed in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
