### PR TITLE
Potential fix for code scanning alert no. 6: Database query built from user-controlled sources

### DIFF
--- a/svc-gateway/internal/repo/document.go
+++ b/svc-gateway/internal/repo/document.go
@@ -81,14 +81,31 @@ func (r *documentRepo) FindByUserID(ctx context.Context, userID uint, filter Lis
 	}
 
 	orderBy := "created_at DESC, id DESC"
-	if filter.SortBy != "" {
-		dir := "DESC"
-		if filter.SortOrder == "asc" {
-			dir = "ASC"
+	ascending := filter.SortOrder == "asc"
+	switch filter.SortBy {
+	case "title":
+		if ascending {
+			orderBy = "title ASC, id ASC"
+		} else {
+			orderBy = "title DESC, id DESC"
 		}
-		switch filter.SortBy {
-		case "title", "file_size", "view_count", "created_at":
-			orderBy = filter.SortBy + " " + dir + ", id " + dir
+	case "file_size":
+		if ascending {
+			orderBy = "file_size ASC, id ASC"
+		} else {
+			orderBy = "file_size DESC, id DESC"
+		}
+	case "view_count":
+		if ascending {
+			orderBy = "view_count ASC, id ASC"
+		} else {
+			orderBy = "view_count DESC, id DESC"
+		}
+	case "created_at":
+		if ascending {
+			orderBy = "created_at ASC, id ASC"
+		} else {
+			orderBy = "created_at DESC, id DESC"
 		}
 	}
 

--- a/svc-gateway/internal/repo/document.go
+++ b/svc-gateway/internal/repo/document.go
@@ -36,7 +36,7 @@ type DocumentRepository interface {
 	IncrementLikeCount(ctx context.Context, id uint) error
 	UpdateVisibility(ctx context.Context, docID, ownerID uint, visibility string, labID *uint) error
 	BatchUpdateVisibility(ctx context.Context, docIDs []uint, ownerID uint, visibility string, labID *uint) (int64, error)
-	UpdateMetadata(ctx context.Context, docID, ownerID uint, fields map[string]any) error
+	UpdateMetadata(ctx context.Context, docID, ownerID uint, patch DocumentMetadataPatch) error
 	DeleteByID(ctx context.Context, docID, ownerID uint) (model.Document, error)
 }
 
@@ -227,10 +227,30 @@ func (r *documentRepo) UpdateVisibility(ctx context.Context, docID, ownerID uint
 	return nil
 }
 
-// UpdateMetadata patches user-editable metadata fields (title, year, doi) on a
-// document the caller owns. The fields map contains only the keys that should
-// change — callers must restrict it to safe columns.
-func (r *documentRepo) UpdateMetadata(ctx context.Context, docID, ownerID uint, fields map[string]any) error {
+// DocumentMetadataPatch enumerates the columns UpdateMetadata is allowed to
+// touch. A nil pointer means "leave this column as-is"; a non-nil pointer
+// (including an empty string / zero) is applied as-is. Keeping this as a typed
+// struct owned by the repo means column names never cross the service ↔ repo
+// boundary as strings, which rules out column-name injection by construction.
+type DocumentMetadataPatch struct {
+	Title *string
+	Year  *int
+	DOI   *string
+}
+
+// UpdateMetadata patches user-editable metadata fields on a document the
+// caller owns. Only fields set on the patch are written.
+func (r *documentRepo) UpdateMetadata(ctx context.Context, docID, ownerID uint, patch DocumentMetadataPatch) error {
+	fields := map[string]any{}
+	if patch.Title != nil {
+		fields["title"] = *patch.Title
+	}
+	if patch.Year != nil {
+		fields["year"] = *patch.Year
+	}
+	if patch.DOI != nil {
+		fields["doi"] = *patch.DOI
+	}
 	if len(fields) == 0 {
 		return nil
 	}

--- a/svc-gateway/internal/service/document.go
+++ b/svc-gateway/internal/service/document.go
@@ -566,20 +566,12 @@ func (s *DocumentService) BatchUpdateVisibility(ctx context.Context, userID uint
 // The three fields are nullable columns, so clients can clear them by sending
 // an explicit empty string / zero — callers send `null` via JSON to mean "no change".
 func (s *DocumentService) UpdateMetadata(ctx context.Context, userID, docID uint, req dto.UpdateDocumentMetadataRequest) error {
-	fields := map[string]any{}
-	if req.Title != nil {
-		fields["title"] = *req.Title
+	patch := repo.DocumentMetadataPatch{
+		Title: req.Title,
+		Year:  req.Year,
+		DOI:   req.DOI,
 	}
-	if req.Year != nil {
-		fields["year"] = *req.Year
-	}
-	if req.DOI != nil {
-		fields["doi"] = *req.DOI
-	}
-	if len(fields) == 0 {
-		return nil
-	}
-	if err := s.repo.UpdateMetadata(ctx, docID, userID, fields); err != nil {
+	if err := s.repo.UpdateMetadata(ctx, docID, userID, patch); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return app_error.ErrNotDocumentOwner
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/ZureTz/sci-vault/security/code-scanning/6](https://github.com/ZureTz/sci-vault/security/code-scanning/6)

The best fix is to stop concatenating any user-influenced strings for `ORDER BY` and instead map validated sort options to fixed, hard-coded SQL fragments.

In `svc-gateway/internal/repo/document.go` inside `FindByUserID` (around lines 83–93), replace the dynamic `dir` + concatenation logic with a nested allowlist mapping:
- default `orderBy` stays `"created_at DESC, id DESC"`.
- if `SortBy` is valid, choose a constant for asc/desc variant directly:
  - `title` -> `"title ASC, id ASC"` / `"title DESC, id DESC"`
  - `file_size` -> `"file_size ASC, id ASC"` / `"file_size DESC, id DESC"`
  - `view_count` -> `"view_count ASC, id ASC"` / `"view_count DESC, id DESC"`
  - `created_at` -> `"created_at ASC, id ASC"` / `"created_at DESC, id DESC"`
- normalize `SortOrder` by checking only `"asc"`; otherwise use desc.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
